### PR TITLE
Deprecate output-colored flag

### DIFF
--- a/cmd/rostamctl/rostamctl.go
+++ b/cmd/rostamctl/rostamctl.go
@@ -45,13 +45,12 @@ func NewCommand() *cobra.Command {
 				return err
 			}
 			cli.GlobalFlags = flg
-			cli.OutputBuilder = output.NewBuilder(flg.OutputFormat, flg.OutputColored)
+			cli.OutputBuilder = output.NewBuilder(flg.OutputFormat)
 			return nil
 		},
 	}
 
-	cmd.PersistentFlags().StringVar(&flg.OutputFormat, "output-format", flags.DefaultOutputFormat, "output format "+output.FormatStrings())
-	cmd.PersistentFlags().BoolVar(&flg.OutputColored, "output-colored", false, "Enable or disable colored output")
+	cmd.PersistentFlags().StringVar(&flg.OutputFormat, "output", flags.DefaultOutputFormat, "output format "+output.FormatStrings())
 	cmd.PersistentFlags().StringVar(&flg.LogLevel, "loglevel", flags.DefaultLogLevel.String(), "log level "+logutil.LevelsString())
 
 	cmd.AddCommand(completion.NewCommand(cli))

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -22,9 +22,8 @@ import (
 
 // GlobalFlags for the rostamctl command
 type GlobalFlags struct {
-	LogLevel      string
-	OutputColored bool
-	OutputFormat  string
+	LogLevel     string
+	OutputFormat string
 }
 
 // Normalize checks and normalizes input flags and falls back to default values when needed

--- a/pkg/output/builder.go
+++ b/pkg/output/builder.go
@@ -18,15 +18,13 @@ package output
 // create a Formatter and use it to print the 'object'
 // to different formats and colors (based on the flags)
 type Builder struct {
-	format  string
-	colored bool
+	format string
 }
 
 // NewBuilder returns a new output.Builder with desired format and colored output
-func NewBuilder(format string, colored bool) *Builder {
+func NewBuilder(format string) *Builder {
 	return &Builder{
-		format:  format,
-		colored: colored,
+		format: format,
 	}
 }
 

--- a/pkg/output/formatter.go
+++ b/pkg/output/formatter.go
@@ -50,9 +50,6 @@ func (f *Formatter) toJSON(object interface{}, builder *Builder) error {
 		return err
 	}
 	jsoned = pretty.Pretty(jsoned)
-	if builder.colored {
-		jsoned = pretty.Color(jsoned, nil)
-	}
 	_, err = fmt.Printf("%s", jsoned)
 	return err
 }
@@ -64,10 +61,6 @@ func (f *Formatter) toYAML(object interface{}, builder *Builder) error {
 	if err != nil {
 		return err
 	}
-	// TODO colorize yaml
-	// if builder.colored {
-	// yamled = Color(yamled, nil)
-	// }
 	_, err = fmt.Printf("%s", yamled)
 	return err
 }


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

### Description

This is a BREAKING CHANGE, flag `--output-colored` is being depracated and `--output-format` is being rename to simply `--output`.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

#### Tests

- [ ] I have added tests to cover my changes.
- [ ] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
- [ ] All checks pass when I run `make checkfmt` and `make lint`.
